### PR TITLE
Replace function_entry prototype by zend_function_entry.

### DIFF
--- a/phrasea2.cpp
+++ b/phrasea2.cpp
@@ -49,7 +49,7 @@ ZEND_DECLARE_MODULE_GLOBALS(phrasea2)
 
 // -----------------------------------------------------------------------------
 // option -Wno-write-strings to gcc prevents warnings on this section
-static function_entry phrasea2_functions[] = {
+static zend_function_entry phrasea2_functions[] = {
 	PHP_FE(phrasea_info, NULL)
 	PHP_FE(phrasea_conn, NULL)
 	PHP_FE(phrasea_create_session, NULL)


### PR DESCRIPTION
php5.4 no longer provide php3 compatibility headers.

See https://github.com/php/php-src/commit/26b08f9857e79b3281d580846e8eb9c27b24af32 for the original commit in php5 tree.
